### PR TITLE
Podspec修正 - Swift Version指定, IronSourceSDK/Ads指定

### DIFF
--- a/IronSourceMaioCustomAdapter.podspec
+++ b/IronSourceMaioCustomAdapter.podspec
@@ -26,14 +26,14 @@ Custom adapter for connecting IronSource and Maio.
   s.license          = { :type => 'Apache-2.0', :file => 'LICENSE' }
   s.author           = 'i-mobile'
   s.source           = { :git => 'https://github.com/imobile/IronSource-maio-CustomAdapter-iOS.git', :tag => s.version.to_s }
-  # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
   s.ios.deployment_target = '12.0'
+  s.swift_version    = '5.0'
 
   s.source_files = 'ISMaioCustomAdapter/ISMaioCustomAdapter/**/*'
   s.static_framework = true
 
   # s.frameworks = 'UIKit', 'MapKit'
   s.dependency 'MaioSDK-v2', '>= 2.1.5'
-  s.dependency 'IronSourceSDK', '>= 8.4.0'
+  s.dependency 'IronSourceSDK/Ads', '>= 8.9.0'
 end


### PR DESCRIPTION
## 背景

弊社のアプリに IronSource Custom Adapter を導入したところ、導入途中にて躓いた点がありましたのでその修正になります。

## 修正内容

1. Swift Version 指定
  - 弊社では Objective-C しか使用していないため、SWIFT_VERSIONの指定が無いので、`pod install` の時点でインストールが不可能でした。podspecにて `s.swift_version` を指定するよう変更しました。
  - swiftの最新バージョンは 6.0 なのですが、ビルドに失敗するので 5.0 を指定しています。
2. `IronSourceSDK/Ads` の依存性を指定
  - IronSource 8.9.0 以降では AdQuality というフレームワークが IronSource に含まれるのですが、他社SDKも含まれている場合 AdQuality によってアプリがクラッシュしてしまうため、動作に必須な Ads のみに依存関係を修正しました。（弊社ではAdsだけで動くことを確認済みです）
  - なお、`8.9.0` 以前には subspecs が無いため、`8.9.0` 以前にも対応する場合は以下のような修正が必要になるかなと思います（未検証です）

```ruby
- s.dependency 'IronSourceSDK/Ads', '>= 8.9.0'

+  # Default to the Ads-only path for IronSource >= 8.9.0
+  s.default_subspec = 'Ads'
+
+  # Modern path: IronSource 8.9.0+ WITH Ads subspec (no AdQuality)
+  s.subspec 'Ads' do |ss|
+    ss.dependency 'IronSourceSDK/Ads', '>= 8.9.0'
+  end
+
+  # Legacy path: IronSource 8.4.0 ..< 8.9.0 (umbrella pod)
+  s.subspec 'Legacy' do |ss|
+    ss.dependency 'IronSourceSDK', '>= 8.4.0', '< 8.9.0'
+  end

---

# 8.9.0以上
pod 'IronSourceMaioCustomAdapter'

# 8.9.0未満
pod 'IronSourceMaioCustomAdapter/Legacy'
```